### PR TITLE
Fix: reentrancy attack during drawLoan

### DIFF
--- a/contracts/contracts/PawnBank.sol
+++ b/contracts/contracts/PawnBank.sol
@@ -255,12 +255,13 @@ contract PawnBank {
     // Prevent drawing from a loan with 0 available capital
     require(loan.loanAmountDrawn < loan.loanAmount, "Max draw capacity reached.");
 
-    // Draw the maximum available loan capital
-    (bool sent, ) = payable(msg.sender).call{value: loan.loanAmount - loan.loanAmountDrawn}("");
-    require(sent == true, "Failed to draw capital.");
-
+    // Calculate capital to draw
+    uint256 _availableCapital = loan.loanAmount - loan.loanAmountDrawn;
     // Update drawn amount to current loan capacity
     loan.loanAmountDrawn = loan.loanAmount;
+    // Draw the maximum available loan capital
+    (bool sent, ) = payable(msg.sender).call{value: _availableCapital}("");
+    require(sent == true, "Failed to draw capital.");
 
     // Emit draw event
     emit LoanDrawn(_loanId);


### PR DESCRIPTION
Fixes #2 by adhering to the [checks-effects-interactions pattern](https://docs.soliditylang.org/en/v0.5.11/security-considerations.html#use-the-checks-effects-interactions-pattern) and moving the update to `loan.loanAmountDrawn` to before the draw capital contract call.

**Credit**
Thank you to [@mrthankyou](https://github.com/mrthankyou) for the find!